### PR TITLE
fixed broken syntax for scene headings, combined FountainFolds() into syntax

### DIFF
--- a/syntax/fountain.vim
+++ b/syntax/fountain.vim
@@ -11,6 +11,7 @@ if exists("b:current_syntax")
 endif
 syn sync minlines=200
 
+syn match fountainAction "^\(\a\)*\s*.*$" contains=fountainBoneyard,fountainNotes
 syn match fountainSection1 "^\s*# \(\_[^#]\)" fold transparent contains=ALL
 syn region fountainTitlePage start="\%^\(.*\):" end="^$" contains=fountainBoneyard,fountainNotes
 syn match fountainCharacter "\(^\s*@\(.*\)\)\|\(^\(\L\)*$\)" 
@@ -33,25 +34,27 @@ syn region fountainHeader4 start="^\s*#### " end="$" contains=fountainBoneyard,f
 syn region fountainHeader5 start="^\s*##### " end="$" contains=fountainBoneyard,fountainNotes
 syn region fountainHeader6 start="^\s*###### " end="$" contains=fountainBoneyard,fountainNotes
 syn region fountainSynopses start="^\s*= " end="$" contains=fountainBoneyard,fountainNotes
-syn region fountainSceneHeading start="^\s*\(\.[^\. ]\|INT\. \|EXT\. \|INT\./EXT\. \|INT/EXT\. \|INT \|EXT \|INT/EXT \|I/E \|int\. \|ext\. \|int\./ext\. \|int/ext\. \|int \|ext \|int/ext \|i/e \)" end="$" contains=fountainSceneNumber,fountainBoneyard,fountainNotes 
+syn region fountainSceneHeading start="^\s*\(\.[^\. ]\|INT\. \|EXT\. \|INT\.\/EXT\. \|INT\/EXT\. \|INT \|EXT \|INT\/EXT \|I\/E \)\c" end="$" contains=fountainSceneNumber,fountainBoneyard,fountainNotes 
+syn region fountainAction matchgroup=fountainSceneHeading start="^\s*\(\.[^\. ]\|INT\. \|EXT\. \|INT\.\/EXT\. \|INT\/EXT\. \|INT \|EXT \|INT\/EXT \|I\/E \)\(.*\)$\n*\ze\a\c" end="\n\n" contains=fountainBoneyard,fountainNotes,fountainBold,fountainUnderlined,fountainItalic,fountainBoldItalic
 syn region fountainBoneyard start="/\*" end="\*\/" contains=xLineContinue
 syn match xLineContinue "\\$" contained
 syn region fountainSceneNumber start="#" end="#" contained
 
-hi def link fountainTitlePage		    title
-hi def link fountainSection1 				Underlined
+hi def link fountainTitlePage		    PreProc
+hi def link fountainSection1 			Underlined
 hi def link fountainSceneHeading	    title
+hi def link fountainAction              string
 hi def link fountainCharacter			identifier 
 hi def link fountainDialogue			statement
-hi def link fountainParenthetical		vimIsCommand
+hi def link fountainParenthetical		conditional
 hi def link fountainTransition			todo
-hi def link fountainLyric						normal
+hi def link fountainLyric				normal
 hi def link fountainTransitionForced	todo
 hi def link fountainCentered			character
-hi fountainUnderlined					gui=underline
-hi fountainItalic						gui=italic cterm=italic	
-hi fountainBold							gui=bold cterm=bold
-hi fountainBoldItalic					gui=bold,italic cterm=bold,italic	
+hi def fountainUnderlined					gui=underline
+hi def fountainItalic						gui=italic cterm=italic	
+hi def fountainBold							gui=bold cterm=bold
+hi def fountainBoldItalic					gui=bold,italic cterm=bold,italic	
 hi def link fountainPagebreak			conditional
 hi def link fountainActionForced		normal
 hi def link fountainNotes				comment
@@ -65,4 +68,36 @@ hi def link fountainHeader6				CursorLineNr
 hi def link fountainSynopses			number
 hi def link fountainSceneNumber			number	
 
+function! FountainFolds()
+  let thisline = getline(v:lnum)
+  let laterline = getline(v:lnum + 2)
+  if match(thisline, '^EXT') >= 0
+    return ">1"
+  elseif match(thisline, '^INT') >= 0
+    return ">1"
+	elseif match(thisline, '^Title:') >= 0
+    return ">1"
+  elseif match(thisline, '^\.[^.]') >= 0
+    return ">1"
+  elseif match(laterline, '^EXT') >= 0
+    return "<1"
+  elseif match(laterline, '^INT') >= 0
+    return "<1"
+  elseif match(laterline, '^Title:') >= 0
+    return "<1"
+  elseif match(laterline, '^\.[^.]') >= 0
+    return "<1"
+  else
+    return "="
+  endif
+endfunction
+
+setlocal foldmethod=expr
+setlocal foldexpr=FountainFolds()
+
+function! FountainFoldText()
+  let foldsize = (v:foldend-v:foldstart)
+  return getline(v:foldstart).' ('.foldsize.' lines)'
+endfunction
+setlocal foldtext=FountainFoldText()
 let b:current_syntax = "fountain"


### PR DESCRIPTION
regex for scene headings did not escape forward slashes.
this also cleans up some other missing/odd choices and incorporates folding